### PR TITLE
Remove invalid #endif

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,6 @@ NASM also provides ```%ifdef``` directive that works with ```%elif``` and the ot
 %undef LINUX
 %ifdef LINUX
 ; do linux things
-%endif
 %else
 ; do mac things
 %endif


### PR DESCRIPTION
I'm guessing this is what you meant. Do one thing or the other based on whether LINUX is defined using %ifdef/%else/%endif.