### PR TITLE
Fix in the 'Boolean Algebra' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,9 @@ This is a most important concept to grasp!
 
 We use the Boolean Algebra operators on words to achieve useful results.  
 
-A typical use of the AND operator is to clear bits in a value.  If we AND with a value that is the inverse of a power of 2, we are simply clearing a bit.  n AND !4 clears bit 3 in n. 
+A typical use of the AND operator is to clear bits in a value.  If we AND with a value that is the inverse of a power of 2, we are simply clearing a bit.  n AND !8 clears bit 3 in n. 
 
-A typical use of the OR operator is to set bits in a value.  If we OR with a value that is a power of 2, we are simply setting a bit.  n OR 4 sets bit 3 in n.
+A typical use of the OR operator is to set bits in a value.  If we OR with a value that is a power of 2, we are simply setting a bit.  n OR 8 sets bit 3 in n.
 
 A great use of the AND operator is to do a modulo of a number to a power of 2.  For example, AND with 3 gets you a result between 0 and 3.  AND with 7 gets you a result between 0 and 7.
 


### PR DESCRIPTION
Firstly, thank you very much for this wonderful tutorial! I'm having a great time reading it.

I noticed a small inconsistency in the Boolean algebra section, particularly in the discussion about using AND or OR operations to set or clear bits. The statement *"n AND !4 clears bit 3 in n"* is incorrect when we assume that the smallest digit is bit 0 (it would have been correct if the smallest digit was bit 1 instead). The same holds for the statement *"n OR 4 sets bit 3 in n"*.

These statements are also inconsistent with the examples on setting and clearing bits that were provided at the end of the "Bit Shifting" section (line 290-296).

Changing the "4" to "8" in both statements should fix this issue. Hope this helps!